### PR TITLE
Fix for installation with ruby 2.6.0-preview2

### DIFF
--- a/ast_tools.gemspec
+++ b/ast_tools.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ''
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '= 2.6.0-preview2'
+  spec.required_ruby_version = '>= 2.6.0'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
required_ruby_version = '= 2.6.o-preview2' does not allow
this gem to be installed with ruby 2.6.0-preview2.